### PR TITLE
fix: add ProxyPool config merging in mergeConfig()

### DIFF
--- a/main.go
+++ b/main.go
@@ -717,6 +717,19 @@ func mergeConfig(base, loaded *AppConfig) {
 	// Flow 配置
 	base.Flow = loaded.Flow
 
+	// ProxyPool 配置
+	if len(loaded.ProxyPool.Subscribes) > 0 {
+		base.ProxyPool.Subscribes = loaded.ProxyPool.Subscribes
+	}
+	if len(loaded.ProxyPool.Files) > 0 {
+		base.ProxyPool.Files = loaded.ProxyPool.Files
+	}
+	if loaded.ProxyPool.Proxy != "" {
+		base.ProxyPool.Proxy = loaded.ProxyPool.Proxy
+	}
+	base.ProxyPool.HealthCheck = loaded.ProxyPool.HealthCheck
+	base.ProxyPool.CheckOnStartup = loaded.ProxyPool.CheckOnStartup
+
 	// Note
 	if len(loaded.Note) > 0 {
 		base.Note = loaded.Note


### PR DESCRIPTION
## Summary

修复 `mergeConfig()` 函数中遗漏 ProxyPool 配置合并的问题。

### 问题描述

当前版本中，`config.json` 里的 `proxy_pool` 配置（包括 `subscribes`、`files`、`proxy` 等）无法生效，只有环境变量 `PROXY` 能正常工作。

### 根因分析

`main.go` 中的 `mergeConfig()` 函数（约第 661-724 行）负责将用户配置文件合并到默认配置，但完全遗漏了 `ProxyPool` 配置的合并逻辑：

```go
// 原代码中处理了以下配置：
// - APIKeys
// - ListenAddr
// - DataDir
// - DefaultConfig
// - Debug
// - Pool（账号池配置）
// - PoolServer（C/S架构配置）
// - Flow（Flow配置）
// - Note
// ❌ 但遗漏了 ProxyPool（代理池配置）
```

### 修复内容

在 `mergeConfig()` 函数中添加 ProxyPool 配置合并：

- `ProxyPool.Subscribes` - 代理订阅链接列表
- `ProxyPool.Files` - 本地代理文件路径列表
- `ProxyPool.Proxy` - 单一代理地址
- `ProxyPool.HealthCheck` - 健康检查开关
- `ProxyPool.CheckOnStartup` - 启动时检查开关

### 验证结果

修复前：
```
共加载 0 个代理节点
```

修复后：
```
正在加载代理订阅: https://xxx/sub?token=xxx
成功加载 112 个订阅代理
正在加载代理文件: /app/config/proxies.txt
成功加载 1 个文件代理
共加载 113 个代理节点 (订阅: 1, 文件: 1)
代理池初始化完成，可用代理: 31
```

## Test plan

- [x] 配置 `proxy_pool.subscribes` 验证订阅代理加载
- [x] 配置 `proxy_pool.files` 验证文件代理加载
- [x] 验证代理健康检查正常工作
- [x] 验证账号注册功能使用代理池正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)